### PR TITLE
refactor: create only one instance of the default value in TestData

### DIFF
--- a/test/SimpleTrading.TestInfrastructure/TestDataBuilder/AssetBuilder.cs
+++ b/test/SimpleTrading.TestInfrastructure/TestDataBuilder/AssetBuilder.cs
@@ -11,7 +11,7 @@ public static partial class TestData
         public string Name { get; init; } = "EUR/USD";
         public DateTime CreatedAt { get; init; } = DateTime.Parse("2024-08-03T14:00:00").ToUtcKind();
 
-        public static Asset Default => new();
+        public static Asset Default { get; } = new Lazy<Asset>(() => new Asset()).Value;
 
         public Domain.Trading.Asset Build()
         {

--- a/test/SimpleTrading.TestInfrastructure/TestDataBuilder/CurrencyBuilder.cs
+++ b/test/SimpleTrading.TestInfrastructure/TestDataBuilder/CurrencyBuilder.cs
@@ -10,8 +10,8 @@ public static partial class TestData
         public string IsoCode { get; init; } = "EUR";
         public string Name { get; set; } = "Euro";
         public DateTime CreatedAt { get; init; } = DateTime.Parse("2024-08-03T14:00:00").ToUtcKind();
-
-        public static Currency Default => new();
+        
+        public static Currency Default { get; } = new Lazy<Currency>(() => new Currency()).Value;
 
         public Domain.Trading.Currency Build()
         {

--- a/test/SimpleTrading.TestInfrastructure/TestDataBuilder/ProfileBuilder.cs
+++ b/test/SimpleTrading.TestInfrastructure/TestDataBuilder/ProfileBuilder.cs
@@ -11,7 +11,7 @@ public static partial class TestData
         public string? Description { get; set; } = "";
         public DateTime CreatedAt { get; init; } = DateTime.Parse("2024-08-03T14:00:00").ToUtcKind();
 
-        public static Profile Default => new();
+        public static Profile Default { get; } = new Lazy<Profile>(() => new Profile()).Value;
 
         public Domain.Trading.Profile Build()
         {

--- a/test/SimpleTrading.TestInfrastructure/TestDataBuilder/TradeBuilder.cs
+++ b/test/SimpleTrading.TestInfrastructure/TestDataBuilder/TradeBuilder.cs
@@ -21,7 +21,7 @@ public static partial class TestData
         public string Notes { get; init; } = "";
         public DateTime CreatedAt { get; init; } = DateTime.Parse("2024-08-03T14:00:00").ToUtcKind();
 
-        public static Trade Default => new();
+        public static Trade Default { get; } = new Lazy<Trade>(() => new Trade()).Value;
 
         public Domain.Trading.Trade Build()
         {

--- a/test/SimpleTrading.TestInfrastructure/TestDataBuilder/UserSettingsBuilder.cs
+++ b/test/SimpleTrading.TestInfrastructure/TestDataBuilder/UserSettingsBuilder.cs
@@ -14,8 +14,7 @@ public static partial class TestData
         public string TimeZone { get; set; } = Constants.DefaultTimeZone;
         public DateTime UpdatedAt { get; set; } = DateTime.Parse("2024-08-03T14:00:00").ToUtcKind();
 
-
-        public static UserSettings Default => new();
+        public static UserSettings Default { get; } = new Lazy<UserSettings>(() => new UserSettings()).Value;
 
         public Domain.User.UserSettings Build()
         {


### PR DESCRIPTION
e.g. `TestData.Asset.Default` will now return always the same instance and it is instantiated on the first access.