### PR TITLE
feat: allow clients to send date times in utc and local time

### DIFF
--- a/src/SimpleTrading.Domain/Extensions/DateTimeExtensions.cs
+++ b/src/SimpleTrading.Domain/Extensions/DateTimeExtensions.cs
@@ -2,7 +2,7 @@
 
 public static class DateTimeExtensions
 {
-    public static DateTime ToLocal(this DateTime dateTime, string timeZone)
+    public static DateTimeOffset ToLocal(this DateTime dateTime, string timeZone)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(timeZone, nameof(timeZone));
 
@@ -10,8 +10,9 @@ public static class DateTimeExtensions
             throw new ArgumentException("The given dateTime is not in UTC");
 
         var timeZoneInfo = TimeZoneInfo.FindSystemTimeZoneById(timeZone);
+        var dateTimeOffset = new DateTimeOffset(dateTime);
 
-        return TimeZoneInfo.ConvertTime(dateTime, timeZoneInfo).ToLocalKind();
+        return TimeZoneInfo.ConvertTime(dateTimeOffset, timeZoneInfo);
     }
 
     public static DateTime ToUnspecifiedKind(this DateTime dateTime)

--- a/src/SimpleTrading.Domain/Trading/UseCases/AddTrade/AddTradeInteractor.cs
+++ b/src/SimpleTrading.Domain/Trading/UseCases/AddTrade/AddTradeInteractor.cs
@@ -1,7 +1,6 @@
 ﻿using FluentValidation;
 using OneOf;
 using SimpleTrading.Domain.DataAccess;
-using SimpleTrading.Domain.Extensions;
 using SimpleTrading.Domain.Infrastructure;
 using SimpleTrading.Domain.Resources;
 
@@ -73,7 +72,7 @@ public class AddTradeInteractor(IValidator<AddTradeRequestModel> validator, Trad
             ProfileId = profile.Id,
             Profile = profile,
             Size = model.Size,
-            Opened = model.Opened.ToUtcKind(),
+            Opened = model.Opened.UtcDateTime,
             CurrencyId = currency.Id,
             Currency = currency,
             PositionPrices = new PositionPrices
@@ -115,7 +114,9 @@ public class AddTradeInteractor(IValidator<AddTradeRequestModel> validator, Trad
 
         OneOf<Completed<Trade>, CompletedWithWarnings<Trade>, BusinessError> Close()
         {
-            var result = trade.Close(new Trade.CloseTradeDto(model.Closed!.Value, model.Balance!.Value,
+            var result = trade.Close(new Trade.CloseTradeDto(
+                model.Closed!.Value.UtcDateTime,
+                model.Balance!.Value,
                 utcNow)
             {
                 ExitPrice = model.ExitPrice,

--- a/src/SimpleTrading.Domain/Trading/UseCases/AddTrade/AddTradeRequestModel.cs
+++ b/src/SimpleTrading.Domain/Trading/UseCases/AddTrade/AddTradeRequestModel.cs
@@ -7,8 +7,8 @@ public record AddTradeRequestModel
 {
     public required Guid AssetId { get; init; }
     public required Guid ProfileId { get; init; }
-    public required DateTime Opened { get; init; }
-    public DateTime? Closed { get; set; }
+    public required DateTimeOffset Opened { get; init; }
+    public DateTimeOffset? Closed { get; set; }
     public required decimal Size { get; init; }
     public ResultModel? Result { get; set; }
     public decimal? Balance { get; set; }

--- a/src/SimpleTrading.Domain/Trading/UseCases/CloseTrade/CloseTradeInteractor.cs
+++ b/src/SimpleTrading.Domain/Trading/UseCases/CloseTrade/CloseTradeInteractor.cs
@@ -1,6 +1,7 @@
 ﻿using FluentValidation;
 using OneOf;
 using SimpleTrading.Domain.DataAccess;
+using SimpleTrading.Domain.Extensions;
 using SimpleTrading.Domain.Infrastructure;
 
 namespace SimpleTrading.Domain.Trading.UseCases.CloseTrade;
@@ -31,7 +32,7 @@ public class CloseTradeInteractor(
 
     private async Task<CloseTradeResponse> CloseTrade(Trade trade, CloseTradeRequestModel model)
     {
-        var closeTradeDto = new Trade.CloseTradeDto(model.Closed,
+        var closeTradeDto = new Trade.CloseTradeDto(model.Closed.UtcDateTime,
             model.Balance,
             utcNow)
         {

--- a/src/SimpleTrading.Domain/Trading/UseCases/CloseTrade/CloseTradeRequestModel.cs
+++ b/src/SimpleTrading.Domain/Trading/UseCases/CloseTrade/CloseTradeRequestModel.cs
@@ -5,7 +5,7 @@ namespace SimpleTrading.Domain.Trading.UseCases.CloseTrade;
 
 public record CloseTradeRequestModel(
     Guid TradeId,
-    DateTime Closed,
+    DateTimeOffset Closed,
     decimal Balance,
     ResultModel? Result = null,
     decimal? ExitPrice = null);

--- a/src/SimpleTrading.Domain/Trading/UseCases/GetTrade/GetTradeInteractor.cs
+++ b/src/SimpleTrading.Domain/Trading/UseCases/GetTrade/GetTradeInteractor.cs
@@ -1,5 +1,6 @@
 ﻿using OneOf;
 using SimpleTrading.Domain.DataAccess;
+using SimpleTrading.Domain.Extensions;
 using SimpleTrading.Domain.Infrastructure;
 
 namespace SimpleTrading.Domain.Trading.UseCases.GetTrade;
@@ -12,6 +13,8 @@ public class GetTradeInteractor(TradingDbContext dbContext) : BaseInteractor, IG
         if (trade is null)
             return NotFound<Trade>(tradeId);
 
-        return TradeResponseModel.From(trade);
+        var userSettings = await dbContext.GetUserSettings();
+
+        return TradeResponseModel.From(trade, userSettings.TimeZone);
     }
 }

--- a/src/SimpleTrading.Domain/Trading/UseCases/GetTrade/TradeResponseModel.cs
+++ b/src/SimpleTrading.Domain/Trading/UseCases/GetTrade/TradeResponseModel.cs
@@ -1,3 +1,5 @@
+using SimpleTrading.Domain.Extensions;
+
 namespace SimpleTrading.Domain.Trading.UseCases.GetTrade;
 
 public class TradeResponseModel
@@ -8,8 +10,8 @@ public class TradeResponseModel
     public required Guid ProfileId { get; init; }
     public required string Profile { get; init; }
     public required decimal Size { get; init; }
-    public required DateTime Opened { get; init; }
-    public required DateTime? Closed { get; init; }
+    public required DateTimeOffset Opened { get; init; }
+    public required DateTimeOffset? Closed { get; init; }
     public required decimal? Balance { get; init; }
     public required ResultModel? Result { get; init; }
     public required short? Performance { get; init; }
@@ -24,7 +26,7 @@ public class TradeResponseModel
     public required IReadOnlyList<ReferenceModel> References { get; init; }
     public required string? Notes { get; init; }
 
-    public static TradeResponseModel From(Trade trade)
+    public static TradeResponseModel From(Trade trade, string timeZone)
     {
         return new TradeResponseModel
         {
@@ -34,8 +36,8 @@ public class TradeResponseModel
             ProfileId = trade.ProfileId,
             Profile = trade.Profile.Name,
             Size = trade.Size,
-            Opened = trade.Opened,
-            Closed = trade.Closed,
+            Opened = trade.Opened.ToLocal(timeZone),
+            Closed = trade.Closed?.ToLocal(timeZone),
             Balance = trade.Balance,
             Result = trade.Result?.ToResultModel(),
             Performance = trade.Result?.Performance,

--- a/src/SimpleTrading.WebApi/Extensions/ServiceCollectionExtensions.cs
+++ b/src/SimpleTrading.WebApi/Extensions/ServiceCollectionExtensions.cs
@@ -60,8 +60,12 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<UtcNow>(_ => () => DateTime.UtcNow);
         services.AddSingleton<LocalNow>(sp => async () =>
         {
-            var userSettings = await sp.GetRequiredService<TradingDbContext>().GetUserSettings();
-            return DateTime.UtcNow.ToLocal(userSettings.TimeZone);
+            using var scope = sp.CreateScope();
+            var userSettings = await scope.ServiceProvider
+                .GetRequiredService<TradingDbContext>()
+                .GetUserSettings();
+            
+            return DateTime.UtcNow.ToLocal(userSettings.TimeZone).DateTime.ToLocalKind();
         });
 
         return services;

--- a/src/SimpleTrading.WebApi/Features/Trading/Dto/AddTradeDto.cs
+++ b/src/SimpleTrading.WebApi/Features/Trading/Dto/AddTradeDto.cs
@@ -8,8 +8,8 @@ public record AddTradeDto
 {
     public Guid? AssetId { get; set; }
     public Guid? ProfileId { get; set; }
-    public DateTime? Opened { get; set; }
-    public DateTime? Closed { get; set; }
+    public DateTimeOffset? Opened { get; set; }
+    public DateTimeOffset? Closed { get; set; }
     public decimal? Size { get; set; }
     public ResultDto? Result { get; set; }
     public decimal? Balance { get; set; }

--- a/src/SimpleTrading.WebApi/Features/Trading/Dto/CloseTradeDto.cs
+++ b/src/SimpleTrading.WebApi/Features/Trading/Dto/CloseTradeDto.cs
@@ -17,7 +17,7 @@ public class CloseTradeDto
 {
     public decimal? Balance { get; set; }
     public decimal? ExitPrice { get; set; }
-    public DateTime? Closed { get; set; }
+    public DateTimeOffset? Closed { get; set; }
     public ResultDto? Result { get; set; }
 }
 

--- a/src/SimpleTrading.WebApi/Features/Trading/Dto/TradeDto.cs
+++ b/src/SimpleTrading.WebApi/Features/Trading/Dto/TradeDto.cs
@@ -12,8 +12,8 @@ public class TradeDto
     public Guid ProfileId { get; init; }
     public required string Profile { get; init; }
     public decimal Size { get; init; }
-    public DateTime Opened { get; init; }
-    public DateTime? Closed { get; init; }
+    public DateTimeOffset Opened { get; init; }
+    public DateTimeOffset? Closed { get; init; }
     public decimal? Balance { get; init; }
     public ResultDto? Result { get; init; }
     public short? Performance { get; init; }

--- a/src/SimpleTrading.WebApi/Features/Trading/TradesController.cs
+++ b/src/SimpleTrading.WebApi/Features/Trading/TradesController.cs
@@ -91,7 +91,7 @@ public class TradesController : ControllerBase
         var tradeResult = MapToResultModel(dto.Result);
 
         var closeTradeRequestModel = new CloseTradeRequestModel(tradeId,
-            (DateTime) dto.Closed!,
+            dto.Closed!.Value,
             dto.Balance!.Value,
             tradeResult,
             dto.ExitPrice);

--- a/src/SimpleTrading.WebApi/appsettings.Development.json
+++ b/src/SimpleTrading.WebApi/appsettings.Development.json
@@ -9,7 +9,7 @@
     "LogLevel": {
       "Default": "Debug",
       "Microsoft": "Warning",
-      "Microsoft.AspNetCore": "Information"
+      "Microsoft.AspNetCore": "Warning"
     }
   }
 }

--- a/test/SimpleTrading.Domain.Tests/Extensions/DateTimeExtensionsTests.cs
+++ b/test/SimpleTrading.Domain.Tests/Extensions/DateTimeExtensionsTests.cs
@@ -12,9 +12,8 @@ public class DateTimeExtensionsTests
 
         var newYork = utc.ToLocal("America/New_York");
 
-        var expected = DateTime.Parse("2024-08-03T14:00:00");
+        var expected = DateTimeOffset.Parse("2024-08-03T14:00:00-04:00");
         newYork.Should().Be(expected);
-        newYork.Kind.Should().Be(DateTimeKind.Local);
     }
 
     [Fact]


### PR DESCRIPTION
There are three ways a date time can be send to the backend: 

- UTC
- Local
- Unspecified

UTC and Local will be converted correctly, but Unspecified gets converted to the server's time zone, 
that is UTC in production.