### PR TITLE
feat: add default sorting for trades if no one was specified

### DIFF
--- a/src/SimpleTrading.Domain/Trading/UseCases/SearchTrades/SearchTradesInteractor.cs
+++ b/src/SimpleTrading.Domain/Trading/UseCases/SearchTrades/SearchTradesInteractor.cs
@@ -30,6 +30,7 @@ public class SearchTradesInteractor(
             return BadInput(validationResult);
 
         var sorting = model.Sort
+            .DefaultIfEmpty(new SortModel(nameof(Trade.Opened), false))
             .Select(x => sorterByName[x.Property](x.Ascending ? Order.Ascending : Order.Descending));
 
         var filter = model.Filter


### PR DESCRIPTION
they will be descending sorted by the opened date